### PR TITLE
fix where the PGDATA is located

### DIFF
--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -46,7 +46,7 @@ locals {
           },
           {
             name  = "PGDATA"
-            value = "/data"
+            value = "/data/keycloak/postgres/postgres-0"
           },
           {
             name  = "POSTGRES_PORT"


### PR DESCRIPTION
Fixes where to look for the PGDATA. So when a new build is triggered the postgres db doesn't fail or think it needs to start a new fresh install.

> All the data needed for a database cluster is stored within the cluster's data directory, commonly referred to as PGDATA (after the name of the environment variable that can be used to define it). A common location for PGDATA is /var/lib/pgsql/data. Multiple clusters, managed by different server instances, can exist on the same machine