### PR TITLE
corrected typo with sub_path volume mount config

### DIFF
--- a/modules/cassandra/main.tf
+++ b/modules/cassandra/main.tf
@@ -104,7 +104,7 @@ locals {
           {
             name       = "config"
             mount_path = "/etc/security/limits.conf"
-            subpath    = limits.conf
+            sub_path   = limits.conf
           }
         ]
       },


### PR DESCRIPTION
Same.